### PR TITLE
Add desktop movement controls for local desktop testing

### DIFF
--- a/player.gd
+++ b/player.gd
@@ -1,28 +1,71 @@
 extends CharacterBody3D
 
-
 const SPEED = 5.0
 const JUMP_VELOCITY = 4.5
+const MOUSE_SENSITIVITY = 0.003 
 
+@onready var spring_arm = $SpringArm3D # Grabs the SpringArm for looking up/down
+
+var is_desktop_mode = false # Used to toggle controls off for VR
+
+func _ready() -> void:
+    # Check if VR is active
+    var xr_interface = XRServer.find_interface("OpenXR")
+    if xr_interface and xr_interface.is_initialized():
+        print("VR Mode detected. Desktop controls disabled.")
+        set_physics_process(false)
+        set_process_input(false)
+        return
+        
+    # Desktop Mode setup
+    print("Desktop Mode active.")
+    is_desktop_mode = true
+    Input.mouse_mode = Input.MOUSE_MODE_CAPTURED # Hides and locks the mouse
+
+func _input(event: InputEvent) -> void:
+    if not is_desktop_mode:
+        return
+        
+    # Press ESC to free mouse so window can close
+    if event.is_action_pressed("ui_cancel"):
+        Input.mouse_mode = Input.MOUSE_MODE_VISIBLE
+        
+    # Click the screen to lock the mouse again
+    if event is InputEventMouseButton and event.pressed:
+        Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
+
+    # Handle Mouse Turning
+    if event is InputEventMouseMotion and Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
+        # Turn left/right
+        rotate_y(-event.relative.x * MOUSE_SENSITIVITY)
+        # Look up/down
+        spring_arm.rotate_x(-event.relative.y * MOUSE_SENSITIVITY)
+        # Prevent the camera from doing a full 360-degree flip
+        spring_arm.rotation.x = clamp(spring_arm.rotation.x, -PI/2, PI/4)
 
 func _physics_process(delta: float) -> void:
-	# Add the gravity.
-	if not is_on_floor():
-		velocity += get_gravity() * delta
+    if not is_desktop_mode:
+        return
 
-	# Handle jump.
-	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
-		velocity.y = JUMP_VELOCITY
+    # Add the gravity.
+    if not is_on_floor():
+        velocity += get_gravity() * delta
 
-	# Get the input direction and handle the movement/deceleration.
-	# As good practice, you should replace UI actions with custom gameplay actions.
-	var input_dir := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
-	var direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
-	if direction:
-		velocity.x = direction.x * SPEED
-		velocity.z = direction.z * SPEED
-	else:
-		velocity.x = move_toward(velocity.x, 0, SPEED)
-		velocity.z = move_toward(velocity.z, 0, SPEED)
+    # Handle jump.
+    if Input.is_action_just_pressed("ui_accept") and is_on_floor():
+        velocity.y = JUMP_VELOCITY
 
-	move_and_slide()
+    # Get the input direction and handle the movement/deceleration.
+    var input_dir := Input.get_vector("move_left", "move_right", "move_forward", "move_back")
+    
+    # transform.basis translates the inputs so player moves relative to where they are looking (strafing)
+    var direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
+    
+    if direction:
+        velocity.x = direction.x * SPEED
+        velocity.z = direction.z * SPEED
+    else:
+        velocity.x = move_toward(velocity.x, 0, SPEED)
+        velocity.z = move_toward(velocity.z, 0, SPEED)
+
+    move_and_slide()

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,33 @@ run/main_scene="uid://c4frtv7b1qxyc"
 config/features=PackedStringArray("4.6", "Forward Plus")
 config/icon="res://icon.svg"
 
+[display]
+
+window/size/mode=2
+
+[input]
+
+move_forward={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
+]
+}
+move_back={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"location":0,"echo":false,"script":null)
+]
+}
+move_left={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":97,"location":0,"echo":false,"script":null)
+]
+}
+move_right={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"location":0,"echo":false,"script":null)
+]
+}
+
 [physics]
 
 3d/physics_engine="Jolt Physics"

--- a/world.tscn
+++ b/world.tscn
@@ -265,7 +265,10 @@ shape = SubResource("CapsuleShape3D_gv5m4")
 [node name="MeshInstance3D" type="MeshInstance3D" parent="Player" unique_id=2019052881]
 mesh = SubResource("CapsuleMesh_f3sb7")
 
-[node name="Camera3D" type="Camera3D" parent="Player" unique_id=886325403]
-transform = Transform3D(1, 0, 0, 0, 0.99715894, -0.07532677, 0, 0.07532677, 0.99715894, -0.3600936, 6.1511803, 25.173069)
+[node name="SpringArm3D" type="SpringArm3D" parent="Player" unique_id=584003843]
+spring_length = 3.0
+
+[node name="Camera3D" type="Camera3D" parent="Player/SpringArm3D" unique_id=886325403]
+transform = Transform3D(1, 0, 0, 0, 0.99715894, -0.07532677, 0, 0.07532677, 0.99715894, 0, 0, 0)
 environment = SubResource("Environment_gv5m4")
 fov = 90.0


### PR DESCRIPTION
This needs to be tested again when the VR controls are pushed into main, to test if we can indeed switch between VR and local desktop controls

Closes #33 